### PR TITLE
Define organization-wide repository labels

### DIFF
--- a/universal-repository-labels.json
+++ b/universal-repository-labels.json
@@ -1,0 +1,112 @@
+[
+  {
+    "name": "conclusion: declined",
+    "color": "#b60205",
+    "description": "Will not be worked on."
+  },
+  {
+    "name": "conclusion: duplicate",
+    "color": "#ff0000",
+    "description": "Has already been submitted."
+  },
+  {
+    "name": "conclusion: invalid",
+    "color": "#ff0000",
+    "description": "Off topic or not a bug."
+  },
+  {
+    "name": "help wanted",
+    "color": "#ffa200",
+    "description": "Assistance from the community is especially welcome."
+  },
+  {
+    "name": "priority: high",
+    "color": "#ffa200",
+    "description": ""
+  },
+  {
+    "name": "priority: low",
+    "color": "#c0c0c0",
+    "description": ""
+  },
+  {
+    "name": "status: changes requested",
+    "color": "#ffa200",
+    "description": "Changes to the PR are required before merging."
+  },
+  {
+    "name": "status: in progress",
+    "color": "#0000ff",
+    "description": "Work is in progress on this."
+  },
+  {
+    "name": "status: on hold",
+    "color": "#b60205",
+    "description": "Do not proceed at this time."
+  },
+  {
+    "name": "status: waiting for information",
+    "color": "#ffff00",
+    "description": "More information must be provided before work can proceed."
+  },
+  {
+    "name": "status: blocked",
+    "color": "#b60205",
+    "description": "Progress on this is prevented by an external cause."
+  },
+  {
+    "name": "status: moved",
+    "color": "#000080",
+    "description": "This item was moved to another repository."
+  },
+  {
+    "name": "topic: ci",
+    "color": "#00ffff",
+    "description": "Continuous integration for this repository."
+  },
+  {
+    "name": "topic: firmware",
+    "color": "#00ffff",
+    "description": "Code that runs on an embedded system."
+  },
+  {
+    "name": "topic: software",
+    "color": "#00ffff",
+    "description": "Code that runs on a PC."
+  },
+  {
+    "name": "topic: mechanics",
+    "color": "#00ffff",
+    "description": "Mechanical components of the project."
+  },
+  {
+    "name": "topic: electronics",
+    "color": "#00ffff",
+    "description": "Electronics components of the project."
+  },
+  {
+    "name": "topic: documentation",
+    "color": "#00ffff",
+    "description": "Documentation for the project."
+  },
+  {
+    "name": "type: bug",
+    "color": "#ff0000",
+    "description": ""
+  },
+  {
+    "name": "type: enhancement",
+    "color": "#008000",
+    "description": "PR to improve the project."
+  },
+  {
+    "name": "type: feature request",
+    "color": "#008000",
+    "description": "Issue requesting a new feature to be added."
+  },
+  {
+    "name": "type: support",
+    "color": "#ffff00",
+    "description": "Issue requesting a new feature to be added."
+  }
+]


### PR DESCRIPTION
The default repository labels (used on issues and PRs) provided by GitHub are not ideal for the needs of this organization.

Having a standardized set of repository labels in all repositories of the organization will make them easier to maintain. This can be handled automatically with a scheduled CI workflow that syncs the labels of all repositories from a centralized source, allowing for repository-specific labels to be merged in where appropriate. This file is that centralized source for the organization-wide labels.