### PR TITLE
Add "topic: fpga" to universal repository labels list

### DIFF
--- a/universal-repository-labels.json
+++ b/universal-repository-labels.json
@@ -90,6 +90,11 @@
     "description": "Documentation for the project."
   },
   {
+    "name": "topic: fpga",
+    "color": "#00ffff",
+    "description": "FPGAs: HDL code, simulation, verification, and synthesis."
+  },
+  {
     "name": "type: bug",
     "color": "#ff0000",
     "description": ""


### PR DESCRIPTION
This label will be added to all repositories using the label manager workflow on the next run.

Fixes https://github.com/107-systems/.github/issues/7