### PR TITLE
Add report size deltas workflow template

### DIFF
--- a/workflow-templates/report-size-deltas.properties.json
+++ b/workflow-templates/report-size-deltas.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Report Size Deltas",
+  "description": "Comment to PRs a report of the resulting change in memory usage of the sketches compiled by the arduino/compile-sketches action. WARNING: don't use in private repos (see: https://github.com/arduino/report-size-deltas#run-from-the-same-workflow-as-the-arduinocompile-sketches-action).",
+  "iconName": "report-size-deltas"
+}

--- a/workflow-templates/report-size-deltas.svg
+++ b/workflow-templates/report-size-deltas.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:svg="http://www.w3.org/2000/svg" id="svg2" viewBox="0 0 610 610" version="1.1">
+  <g id="layer4" transform="translate(5 -397.36)">
+    <rect id="rect5840" stroke-linejoin="round" ry="1.5381" height="600" width="600" stroke="#4a0" y="402.36" x="0" stroke-width="10" fill="none"/>
+    <path id="path7_6_" fill="#4a0" d="m177.7 457.36c-72.514 0-131.3 63.481-131.3 141.76 0 159.19 148.65 200.93 250 358.24 95.893-156.3 250-204.19 250-358.24 0-78.275-58.815-141.76-131.3-141.76-52.519 0-97.735 33.495-118.7 81.748-20.96-48.25-66.14-81.75-118.7-81.75z"/>
+  </g>
+  <metadata>
+    <rdf:RDF>
+      <cc:Work>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/publicdomain/"/>
+        <dc:publisher>
+          <cc:Agent rdf:about="http://openclipart.org/">
+            <dc:title>Openclipart</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:title>eco green hearth icon</dc:title>
+        <dc:date>2012-05-29T07:46:10</dc:date>
+        <dc:description>clip art, clipart, ecology, green, hearth, icon, </dc:description>
+        <dc:source>http://openclipart.org/detail/170280/eco-green-hearth-icon-by-cybergedeon</dc:source>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>dominiquechappard</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>clip art</rdf:li>
+            <rdf:li>clipart</rdf:li>
+            <rdf:li>ecology</rdf:li>
+            <rdf:li>green</rdf:li>
+            <rdf:li>hearth</rdf:li>
+            <rdf:li>icon</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/workflow-templates/report-size-deltas.yml
+++ b/workflow-templates/report-size-deltas.yml
@@ -1,0 +1,21 @@
+name: Report Size Deltas
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      # See: https://github.com/arduino/actions/blob/master/libraries/report-size-deltas/README.md
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@main
+        with:
+          # The name of the workflow artifact created by the "Compile Examples" workflow
+          sketches-reports-source: sketches-reports


### PR DESCRIPTION
This will allow the workflow to be added to any public repository under the 107-systems organization by selecting it
from GitHub's "Actions" UI.

https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/sharing-workflows-with-your-organization#creating-a-workflow-template

Fixes https://github.com/107-systems/.github/issues/14