### PR TITLE
Add CI workflow to validate workflows against JSON schema

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,49 @@
+name: Validate GitHub Actions Workflows
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "workflow-templates/*.ya?ml"
+  push:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "workflow-templates/*.ya?ml"
+  # Scheduled trigger to catch workflow failure resulting from changes to the JSON schema
+  schedule:
+    # run every Saturday at 3 AM UTC
+    - cron: "0 3 * * 6"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    env:
+      JSON_SCHEMA_FOLDER: etc/github-workflow-json-schema
+      JSON_SCHEMA_FILENAME: github-workflow.json
+
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v2
+
+      # See: https://github.com/carlosperate/download-file-action/blob/master/README.md
+      - name: Download JSON schema for GitHub Actions workflows
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
+          file-url: https://json.schemastore.org/github-workflow
+          location: ${{ env.JSON_SCHEMA_FOLDER }}
+          file-name: ${{ env.JSON_SCHEMA_FILENAME }}
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      # See: https://github.com/ajv-validator/ajv-cli/blob/master/README.md
+      - name: Validate GitHub Actions workflows
+        run: |
+          ajv -s "${{ env.JSON_SCHEMA_FOLDER }}/${{ env.JSON_SCHEMA_FILENAME }}" -d "./.github/workflows/*.{yml,yaml}"
+          ajv -s "${{ env.JSON_SCHEMA_FOLDER }}/${{ env.JSON_SCHEMA_FILENAME }}" -d "./workflow-templates/*.{yml,yaml}"


### PR DESCRIPTION
Since this repository contains the workflow templates that are distributed to many other repositories, it's especially
important that the workflows be valid.