### PR TITLE
Correct description of "type: support" GitHub label

### DIFF
--- a/universal-repository-labels.json
+++ b/universal-repository-labels.json
@@ -112,6 +112,6 @@
   {
     "name": "type: support",
     "color": "#ffff00",
-    "description": "Issue requesting a new feature to be added."
+    "description": "Request for help using the project."
   }
 ]


### PR DESCRIPTION
A copy paste error caused this label to have the description from "type: feature request".