### PR TITLE
Add front matter to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,11 @@
+---
+name: Bug Report
+about: Report problems with the code in this repository.
+title: ""
+labels: "type: bug"
+assignees: ""
+---
+
 ### :bug: Bug Report
 
 <p align="center">

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,11 @@
+---
+name: Feature Request
+about: Suggest an improvement for this project.
+title: ""
+labels: "type: enhancement"
+assignees: ""
+---
+
 ### ⚡ Feature Request
 
 <p align="center">


### PR DESCRIPTION
There is some required front matter providing metadata. Without this, GitHub does not use the issue template.

Reference:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository

Demo:
https://github.com/per1234-test-org/deleteme/issues/new/choose

Resolves https://github.com/107-systems/.github/issues/31