### PR TITLE
Remove sketch CI status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,3 @@ Repository containing default files for all [107-Systems](https://107-systems.or
 | [107-Arduino-NMEA-Parser](https://github.com/107-systems/107-Arduino-NMEA-Parser) | [![Compile Examples](https://github.com/107-systems/107-Arduino-NMEA-Parser/workflows/Compile%20Examples/badge.svg)](https://github.com/107-systems/107-Arduino-NMEA-Parser/actions?workflow=Compile+Examples) |
 | [107-Arduino-TMF8801](https://github.com/107-systems/107-Arduino-TMF8801) | [![Compile Examples](https://github.com/107-systems/107-Arduino-TMF8801/workflows/Compile%20Examples/badge.svg)](https://github.com/107-systems/107-Arduino-TMF8801/actions?workflow=Compile+Examples) |
 | [107-Arduino-UAVCAN](https://github.com/107-systems/107-Arduino-UAVCAN) | [![Compile Examples](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Compile%20Examples/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Compile+Examples) |
-
-### Arduino Sketch CI Status
-| Sketch | ✔️ / ❌ |
-|:-:|:-:|
-| [Viper-Firmware](https://github.com/107-systems/Viper-Firmware) | [![Compile Sketch status](https://github.com/107-systems/Viper-Firmware/workflows/Compile%20Sketch/badge.svg)](https://github.com/107-systems/Viper-Firmware/actions?workflow=Compile+Sketch) |
-| [UAVCAN-ToF-Distance-Sensor-Node](https://github.com/107-systems/UAVCAN-ToF-Distance-Sensor-Node) | [![Compile Sketch status](https://github.com/107-systems/UAVCAN-ToF-Distance-Sensor-Node/workflows/Compile%20Sketch/badge.svg)](https://github.com/107-systems/UAVCAN-ToF-Distance-Sensor-Node/actions?workflow=Compile+Sketch) |
-| [UAVCAN-GNSS-Node](https://github.com/107-systems/UAVCAN-GNSS-Node) | [![Compile Sketch status](https://github.com/107-systems/UAVCAN-GNSS-Node/workflows/Compile%20Sketch/badge.svg)](https://github.com/107-systems/UAVCAN-GNSS-Node/actions?workflow=Compile+Sketch) |


### PR DESCRIPTION
Because
a) UAVCAN demo applications have been folded into 107-Arduino-UAVCAN
b) Viper-Firmware has been archieved/turned private.